### PR TITLE
Inherit animate_call class for `mergeCalls` usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 # shinyGizmo 0.3
 
-* Fixed #21 - using `mergeCalls` didn't trigger animation calls.
 * Add `jsCallOncePerFlush` function. When used prevents running `conditionalJS` callback during a single flush cycle ([3668](https://github.com/rstudio/shiny/issues/3668)).
 * Add `commonInput` and `commonInputs` functions that allow to gather input from multiple controllers into one.
 * Add `mergeCalls` function that allows to use more than one `jsCalls` for `conditionalJS`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # shinyGizmo 0.3
 
+* Fixed #21 - using `mergeCalls` didn't trigger animation calls.
 * Add `jsCallOncePerFlush` function. When used prevents running `conditionalJS` callback during a single flush cycle ([3668](https://github.com/rstudio/shiny/issues/3668)).
 * Add `commonInput` and `commonInputs` functions that allow to gather input from multiple controllers into one.
 * Add `mergeCalls` function that allows to use more than one `jsCalls` for `conditionalJS`.


### PR DESCRIPTION
Contributes to #21 by inheriting `animate_call` class properly when animation used within `mergeCalls`.
This allows to properly attach `animateCSS` dependency, but doesn't solve animation chaining yet (solution in progress).